### PR TITLE
Support PHP CodeSniffer 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP Code Sniffer configurator",
     "license": "MIT",
     "require": {
-        "squizlabs/php_codesniffer": "~2.3"
+        "squizlabs/php_codesniffer": "~2.3|~3.0"
     },
     "suggest": {
         "m6web/symfony2-coding-standard": "Symfony2 PHP CodeSniffer Coding Standard"


### PR DESCRIPTION
After reading [the release notes](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.0.0) and [the upgrade guide](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Version-3.0-Upgrade-Guide) of v3.0 it seems there is no BC breaks for CLI arguments and options. BC breaks seem to be limited to custom sniffs. So `coke` should work well with both version.